### PR TITLE
Fix token assignment under expiration conditions

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -197,7 +197,10 @@ func (a *Auth) Token() string {
 		return ""
 	}
 	if time.Since(a.expiration) >= -30*time.Second { //in an ideal world this should be zero assuming the instance is synching it's clock
-		*a, _ = GetAuth("", "", "", time.Time{})
+		auth, err := GetAuth("", "", "", time.Time{})
+		if err == nil {
+			*a = auth
+		}
 	}
 	return a.token
 }


### PR DESCRIPTION
Per the pull request at https://github.com/AdRoll/goamz/pull/335, we should not blindly overwrite token after calling GetAuth(). Instead, check for errors and assign only when there is a successful call.
